### PR TITLE
Compatibility fixes for Grimwild in v13

### DIFF
--- a/src/module/maps/grimwild.js
+++ b/src/module/maps/grimwild.js
@@ -1,6 +1,6 @@
-import GenericDiceMap from "./templates/template.js";
+import TemplateDiceMap from "./templates/template.js";
 
-export default class GrimwildDiceMap extends GenericDiceMap {
+export default class GrimwildDiceMap extends TemplateDiceMap {
 	// Ironically, this is used to *remove* extra buttons like the input.
 	// @todo update the parent class to add something like a render hook
 	// for a more accurate place to modify the final markup.
@@ -34,10 +34,8 @@ export default class GrimwildDiceMap extends GenericDiceMap {
 
 	// Override the chat formula logic.
 	updateChatDice(dataset, direction, html) {
-		// Get the DOM element rather than the jQuery object.
-		html = html[0];
 		// Retrieve the current chat value.
-		const chat = html.querySelector("#chat-form textarea");
+		const chat = this.textarea;
 		let currFormula = String(chat.value);
 		// Exit early if there's nothing in chat and this is a remove operation.
 		if (direction === "sub" && currFormula === "") return;
@@ -180,7 +178,6 @@ export default class GrimwildDiceMap extends GenericDiceMap {
 	 * @param {HTMLElement} html
 	 */
 	_createExtraButtons(html) {
-		html = html[0];
 		html.querySelector(".dice-tray__math--sub").remove();
 		html.querySelector(".dice-tray__math--add").remove();
 		html.querySelector(".dice-tray__input").remove();

--- a/src/styles/grimwild.scss
+++ b/src/styles/grimwild.scss
@@ -4,6 +4,10 @@ $gw-orange: #ff6400;
 	.dice-tray {
 		display: flex;
 		width: 100%;
+
+		.dice-tray__math__buttons {
+			margin-top: 0;
+		}
 	}
 
 	.dice-tray__buttons {


### PR DESCRIPTION
## Changes
- Fixed broken grimwild template due to references to `html[0]` which is no longer necessary
- Renamed `GenericDiceMap` import in grimwild.js to `TemplateDiceMap` per the latest version of Dice Tray.
- Fixed slight margin issue on the roll button for Grimwild

## Screenshots
<img width="394" alt="image" src="https://github.com/user-attachments/assets/37ed0c51-f09c-41ba-a09a-dfa83411ff34" />
<img width="399" alt="image" src="https://github.com/user-attachments/assets/3c34d4e9-9c9a-4373-8f34-95183d55a63e" />
