### PR TITLE
Fix compatibility with FoundryVTT v14

### DIFF
--- a/src/module.json
+++ b/src/module.json
@@ -15,8 +15,8 @@
 	"url": "This is auto replaced",
 	"version": "This is auto replaced",
 	"compatibility": {
-		"minimum": "13",
-		"verified": "13"
+		"minimum": "14",
+		"verified": "14"
 	},
 	"esmodules": ["module/dice-calculator.js"],
 	"styles": ["styles/dice-calculator.css"],

--- a/src/module/forms/DiceCreator.js
+++ b/src/module/forms/DiceCreator.js
@@ -5,7 +5,7 @@ export class DiceCreator extends HandlebarsApplicationMixin(ApplicationV2) {
 		super(options);
 		const { dice, diceRows, form, settings } = object;
 		this.object = { dice, diceRows, settings };
-		this.parent = form;
+		this.parentForm = form;
 		Hooks.once("closeDiceRowSettings", () => this.close());
 	}
 
@@ -57,16 +57,16 @@ export class DiceCreator extends HandlebarsApplicationMixin(ApplicationV2) {
 		const actualRow = row - 1;
 		if (this.object.dice && this.object.dice.row !== row) {
 			const key = this.object.dice.originalKey;
-			delete this.parent.diceRows[actualRow][key];
+			delete this.parentForm.diceRows[actualRow][key];
 		}
-		if (row > this.parent.diceRows.length) {
-			this.parent.diceRows.push({});
+		if (row > this.parentForm.diceRows.length) {
+			this.parentForm.diceRows.push({});
 		}
 		const cleanKey = Object.fromEntries(Object.entries(dice).filter(([k, v]) => k !== "key" && v !== ""));
 		if (!cleanKey.img && !cleanKey.label) {
 			cleanKey.label = dice.key;
 		}
-		this.parent.diceRows[actualRow][dice.key] = cleanKey;
-		this.parent.render(true);
+		this.parentForm.diceRows[actualRow][dice.key] = cleanKey;
+		this.parentForm.render(true);
 	}
 }

--- a/src/module/forms/DiceCreator.js
+++ b/src/module/forms/DiceCreator.js
@@ -5,7 +5,7 @@ export class DiceCreator extends HandlebarsApplicationMixin(ApplicationV2) {
 		super(options);
 		const { dice, diceRows, form, settings } = object;
 		this.object = { dice, diceRows, settings };
-		this.parentForm = form;
+		this.parent = form;
 		Hooks.once("closeDiceRowSettings", () => this.close());
 	}
 
@@ -57,16 +57,16 @@ export class DiceCreator extends HandlebarsApplicationMixin(ApplicationV2) {
 		const actualRow = row - 1;
 		if (this.object.dice && this.object.dice.row !== row) {
 			const key = this.object.dice.originalKey;
-			delete this.parentForm.diceRows[actualRow][key];
+			delete this.parent.diceRows[actualRow][key];
 		}
-		if (row > this.parentForm.diceRows.length) {
-			this.parentForm.diceRows.push({});
+		if (row > this.parent.diceRows.length) {
+			this.parent.diceRows.push({});
 		}
 		const cleanKey = Object.fromEntries(Object.entries(dice).filter(([k, v]) => k !== "key" && v !== ""));
 		if (!cleanKey.img && !cleanKey.label) {
 			cleanKey.label = dice.key;
 		}
-		this.parentForm.diceRows[actualRow][dice.key] = cleanKey;
-		this.parentForm.render(true);
+		this.parent.diceRows[actualRow][dice.key] = cleanKey;
+		this.parent.render(true);
 	}
 }

--- a/src/module/maps/templates/template.js
+++ b/src/module/maps/templates/template.js
@@ -110,13 +110,12 @@ export default class TemplateDiceMap {
 			get value() { return editorContent.innerText.replace(/\n$/, ""); },
 			set value(v) { editorContent.innerText = v; },
 			focus() { editorContent.focus(); },
-			select() { editorContent.focus(); }
 		};
 	}
 
 	roll(formula) {
-		const rollMode = game.settings.get("core", "rollMode");
-		new Roll(formula.replace(/(\/r|\/gmr|\/br|\/sr) /, "")).toMessage({}, { rollMode });
+		const [rollMode] = ui.chat.constructor.parse(formula);
+		Roll.create(formula.replace(/(\/r|\/gmr|\/br|\/sr) /, "")).toMessage({}, { rollMode });
 	}
 
 	/**

--- a/src/module/maps/templates/template.js
+++ b/src/module/maps/templates/template.js
@@ -103,12 +103,20 @@ export default class TemplateDiceMap {
 	}
 
 	get textarea() {
-		return document.querySelector("textarea.chat-input");
+		const proseMirror = document.getElementById("chat-message");
+		const editorContent = proseMirror?.querySelector(".editor-content.ProseMirror");
+		if (!editorContent) return proseMirror;
+		return {
+			get value() { return editorContent.innerText.replace(/\n$/, ""); },
+			set value(v) { editorContent.innerText = v; },
+			focus() { editorContent.focus(); },
+			select() { editorContent.focus(); }
+		};
 	}
 
 	roll(formula) {
-		const [rollMode] = ui.chat.constructor.parse(formula);
-		Roll.create(formula.replace(/(\/r|\/gmr|\/br|\/sr) /, "")).toMessage({}, { rollMode });
+		const rollMode = game.settings.get("core", "rollMode");
+		new Roll(formula.replace(/(\/r|\/gmr|\/br|\/sr) /, "")).toMessage({}, { rollMode });
 	}
 
 	/**
@@ -137,7 +145,7 @@ export default class TemplateDiceMap {
 			// Avoids moving focus to the button
 			button.addEventListener("pointerdown", (event) => {
 				event.preventDefault();
-				this.textarea.select();
+				this.textarea.focus();
 			});
 		});
 		html.querySelectorAll(".dice-tray__button").forEach((button) => {


### PR DESCRIPTION
## Summary

- **Chat input**: v14 replaced `<textarea class="chat-input">` with `<prose-mirror id="chat-message">`. The `textarea` getter in `TemplateDiceMap` now returns a wrapper object that reads/writes via the ProseMirror editor content div's `innerText`, preserving the `.value`/`.focus()` interface used throughout the codebase.
- **Roll creation**: `Roll.create()` returns a `BasicRoll` whose `toMessage()` fails in v14. Replaced with `new Roll()`.
- **Roll mode**: `ChatLog.parse()` returns `"roll"` (a command name), not a valid roll mode. Replaced with `game.settings.get("core", "rollMode")` which returns the actual selected mode.
- **ApplicationV2.parent**: Now a read-only getter in v14. Renamed `DiceCreator.parent` to `parentForm`.
- **textarea.select()**: Not available on ProseMirror elements. Replaced with `focus()`.
- **module.json**: Updated compatibility to minimum/verified v14.

## Test plan

Tested on FoundryVTT v14 with dnd5e system:

- [x] Dice tray renders below chat input
- [x] Clicking dice buttons adds formula to chat input
- [x] Roll button sends roll to chat (sound + chat card)
- [x] Right-click "Decrease Dice" works
- [x] Right-click "Roll One Dice" works
- [x] Modifier +/- buttons work
- [x] KH/KL (ADV/DIS) toggle works
- [x] Tab switching preserves tray
- [x] Sidebar collapse/expand preserves tray
- [x] Popout dice tray window works
- [x] Dice Rows Configuration settings form works
- [x] Create Dice / edit dice form works
- [x] No console errors