### PR TITLE
Feature/update style to v14

### DIFF
--- a/src/styles/dice-calculator.scss
+++ b/src/styles/dice-calculator.scss
@@ -6,14 +6,19 @@
 #sidebar-content {
 	.dice-tray {
 		pointer-events: all;
-		margin-top: .5rem;
+	}
+}
+
+#ui-right {
+	.dice-tray {
+		margin-top: 2px;
 	}
 }
 
 #chat-popout,
 #sidebar-content {
 	.dice-tray {
-		margin-top: 0;
+		margin-top: -6px;
 	}
 }
 
@@ -47,7 +52,7 @@
 		}
 	}
 	.dice-tray__math__buttons {
-		margin-top: .2rem;
+		margin-top: 2px;
 	}
 	.dice-tray__input {
 		border-radius: 0;
@@ -94,7 +99,7 @@
 		}
 		.dice-tray__flag {
 			position: absolute;
-			bottom: 100%;
+			bottom: calc(100% - 2px);
 			left: 0;
 			right: 0;
 			font-size: 14px;

--- a/src/styles/dice-calculator.scss
+++ b/src/styles/dice-calculator.scss
@@ -43,6 +43,7 @@
 	.dice-tray__buttons {
 		.dice-tray__button {
 			border-radius: 0;
+
 			&:first-child {
 				border-radius: $border-radius 0 0 $border-radius;
 			}

--- a/src/styles/dice-calculator.scss
+++ b/src/styles/dice-calculator.scss
@@ -49,7 +49,7 @@
 	.dice-tray__math__buttons {
 		margin-top: .2rem;
 	}
-	.tray__input {
+	.dice-tray__input {
 		border-radius: 0;
 	}
 	#dice-tray-math {

--- a/src/styles/dice-calculator.scss
+++ b/src/styles/dice-calculator.scss
@@ -6,28 +6,54 @@
 #sidebar-content {
 	.dice-tray {
 		pointer-events: all;
+		margin-top: .5rem;
 	}
 }
 
 #chat-popout,
 #sidebar-content {
 	.dice-tray {
-		margin-top: -6px;
+		margin-top: 0;
 	}
 }
 
 .dice-tray {
 	.dice-tray__stacked {
 		height: 30px;
+
 		button {
 			min-height: initial;
+
+			&:first-child {
+				border-radius: $border-radius $border-radius 0 0;
+			}
+			&:last-child {
+				border-radius: 0 0 $border-radius $border-radius;
+			}
 		}
 	}
 	.dice-tray__buttons, .dice-tray__math, .dice-tray__input {
 		height: 30px;
 	}
+	.dice-tray__buttons {
+		.dice-tray__button {
+			border-radius: 0;
+			&:first-child {
+				border-radius: $border-radius 0 0 $border-radius;
+			}
+			&:last-child {
+				border-radius: 0 $border-radius $border-radius 0;
+			}
+		}
+	}
 	.dice-tray__math__buttons {
-		margin-top: 2px;
+		margin-top: .2rem;
+	}
+	.tray__input {
+		border-radius: 0;
+	}
+	#dice-tray-math {
+		margin: 0 .2rem;
 	}
 	.flexrow {
 		flex-wrap: nowrap;
@@ -68,7 +94,7 @@
 		}
 		.dice-tray__flag {
 			position: absolute;
-			bottom: calc(100% - 2px);
+			bottom: 100%;
 			left: 0;
 			right: 0;
 			font-size: 14px;
@@ -79,7 +105,7 @@
 			display: flex;
 			align-items: center;
 			justify-content: center;
-			border-radius: 4px 4px 0 0;
+			border-radius: $border-radius $border-radius 0 0;
 			max-height: 18px;
 			transition: all ease-in-out 0.15s;
 			&:hover {
@@ -105,11 +131,15 @@
 			}
 		}
 		&.dice-tray__math--sub {
+			border-radius: 6px 0 0 6px;
+
 			&:hover {
 				@include hover-style($orange);
 			}
 		}
 		&.dice-tray__math--add {
+			border-radius: 0 $border-radius $border-radius 0;
+
 			&:hover {
 				background: $green;
 				border-color: $green;

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -1,6 +1,7 @@
 $white: #fff;
 $orange: var(--color-warm-2);
 $green: #0a9843;
+$border-radius: 4px;
 
 @mixin dice-tray-theme {
 	.dice-tray {


### PR DESCRIPTION
Update style and position for v14 compatibility

Result when is out of the sidebar:
<img width="595" height="319" alt="dice-tray-popup-close" src="https://github.com/user-attachments/assets/659f8ced-a4a2-407d-ad09-5ed177bb3dcb" />

Result when is out of the sidebar, with focus on the input:
<img width="595" height="465" alt="dice-tray-popup-open" src="https://github.com/user-attachments/assets/ca43762c-fe9d-455e-9fa0-c9a1a708e082" />

Result when is on the sidebar:
<img width="510" height="690" alt="dice-tray-sidebar" src="https://github.com/user-attachments/assets/6430d0f7-0b59-490f-aad4-ec18b62fe464" />
