### PR TITLE
Fix DiceCreator settings crash

### DIFF
--- a/src/module/forms/DiceCreator.js
+++ b/src/module/forms/DiceCreator.js
@@ -5,7 +5,7 @@ export class DiceCreator extends HandlebarsApplicationMixin(ApplicationV2) {
 		super(options);
 		const { dice, diceRows, form, settings } = object;
 		this.object = { dice, diceRows, settings };
-		this.parent = form;
+		this.diceRowSettings = form;
 		Hooks.once("closeDiceRowSettings", () => this.close());
 	}
 
@@ -57,16 +57,16 @@ export class DiceCreator extends HandlebarsApplicationMixin(ApplicationV2) {
 		const actualRow = row - 1;
 		if (this.object.dice && this.object.dice.row !== row) {
 			const key = this.object.dice.originalKey;
-			delete this.parent.diceRows[actualRow][key];
+			delete this.diceRowSettings.diceRows[actualRow][key];
 		}
-		if (row > this.parent.diceRows.length) {
-			this.parent.diceRows.push({});
+		if (row > this.diceRowSettings.diceRows.length) {
+			this.diceRowSettings.diceRows.push({});
 		}
 		const cleanKey = Object.fromEntries(Object.entries(dice).filter(([k, v]) => k !== "key" && v !== ""));
 		if (!cleanKey.img && !cleanKey.label) {
 			cleanKey.label = dice.key;
 		}
-		this.parent.diceRows[actualRow][dice.key] = cleanKey;
-		this.parent.render(true);
+		this.diceRowSettings.diceRows[actualRow][dice.key] = cleanKey;
+		this.diceRowSettings.render(true);
 	}
 }


### PR DESCRIPTION
## Summary

- Fixes the Dice Creator settings dialog crash in Foundry v14.
- Avoids assigning Dice Tray state to `ApplicationV2.parent`, which is getter-only.
- Keeps the change scoped to the internal reference used to update and rerender Dice Row Settings.

## Validation

- `npm run lint`
- `npm run build`
